### PR TITLE
Rename the `e` function to `dancepill`

### DIFF
--- a/e
+++ b/e
@@ -1,7 +1,7 @@
 #!/bin/bash
 # :vim sw=2:ts=2:et
 
-e() { 
+dancepill() { 
   for F in "$@"; do
     if [ -f "$F" ] ; then 
       FT1=$(file -bi "$F" | grep -Eo '[[:alnum:]_-]+/[[:alnum:]_-]+')
@@ -34,3 +34,5 @@ e() {
     fi 
   done
 }
+
+alias e=dancepill


### PR DESCRIPTION
People may have other commands aliased to `e` already. This keeps the original
usage intact (source dancepill/e; e package.tar.gz) while allowing people to
re-alias `e` to something else and keep a hold of the original dancepill
function.

Example of the usage this commit allows:

```
# inside ~/.bashrc or whatever
source path/to/dancepill/e
alias extract=dancepill
alias e='emacsclient -t'
```
